### PR TITLE
Use the "windows" subsystem on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "serde",
  "tar",
  "tokio",
+ "winapi 0.3.9",
  "xz2",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ tar = "0.4"
 tokio = { version = "1.0", features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 xz2 = "0.1"
 zip = "0.5"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.9", features = ["wincon"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![windows_subsystem = "windows"]
 #![warn(rust_2018_idioms)]
 //#![allow(dead_code, unused_imports, unused_variables)]
 mod cli;
@@ -15,15 +16,17 @@ use crate::{
 use iced::Application;
 use std::sync::atomic::Ordering;
 
-// TODO: Find a better way of not showing the console on Windows.
-// This option practically disables the CLI. Can't have that.
-// Also, this option doesn't solve the issue of the window spawning south-east of the centre,
-// same placement with and without this option. For some reason it cascades anyway.
-// So a custom solution will probably solve both these issues.
-//#![windows_subsystem = "windows"]
+// TODO: Fix window cascading on Windows. This will involve creating our own window which we'll
+// give to Iced.
 
 #[tokio::main]
 async fn main() {
+    #[cfg(target_os = "windows")]
+    {
+        use winapi::um::wincon;
+        unsafe { wincon::AttachConsole(wincon::ATTACH_PARENT_PROCESS) };
+    }
+
     // TODO: Error handling.
     run().await;
 }


### PR DESCRIPTION
This fixes the following issues:
- Launching the application by double-clicking the executable creates
  an unwanted console window.
- Blender freezes immediately upon being launched. Piping stdin would
  also fix this issue, but the "windows" subsystem approach is strictly
  better.