### PR TITLE
Fixes the parsing of the Blender HTML pages

### DIFF
--- a/src/releases.rs
+++ b/src/releases.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::{Datelike, NaiveDateTime, Utc};
-use select::predicate::{And, Class, Name};
+use select::predicate::{And, Class, Name, Predicate};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fs::{remove_file, File},
@@ -582,11 +582,11 @@ impl BuilderBuild {
         };
 
         let builds_list = document
-            .find(And(Class("builds-list"), Class(platform)))
+            .find(And(Class("builds-list-container"), Class(platform)))
             .next()
             .unwrap();
 
-        for build_node in builds_list.find(Class("os")) {
+        for build_node in builds_list.find(Class("build-info")) {
             let url = build_node
                 .find(Name("a"))
                 .next()
@@ -613,7 +613,7 @@ impl BuilderBuild {
 
             let version = Versioning::new(
                 build_node
-                    .find(Class("name"))
+                    .find(Class("build-title"))
                     .next()
                     .unwrap()
                     .text()
@@ -623,9 +623,9 @@ impl BuilderBuild {
             )
             .unwrap();
 
-            let small_subtext = build_node.find(Name("small")).next().unwrap().text();
-            let parts: Vec<&str> = small_subtext.split_terminator(" - ").collect();
-            let date_string = format!("{}-{}", parts[0], Utc::today().year());
+            let date_without_year = build_node.find(Class("build-details").descendant(Name("li"))).nth(0).unwrap().text();
+            let build_id = build_node.find(Class("build-details").descendant(Name("li"))).nth(1).unwrap().text();
+            let date_string = format!("{}-{}", date_without_year, Utc::today().year());
             let date = NaiveDateTime::parse_from_str(&date_string, "%B %d, %T-%Y").unwrap();
 
             let package = Package {
@@ -633,7 +633,7 @@ impl BuilderBuild {
                 name,
                 build,
                 date,
-                commit: parts[2].to_string(),
+                commit: build_id,
                 url,
                 os,
                 ..Default::default()

--- a/src/releases/stable_latest.rs
+++ b/src/releases/stable_latest.rs
@@ -7,7 +7,7 @@ use crate::{
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
 use derive_deref::{Deref, DerefMut};
-use select::predicate::{Attr, Class, Name};
+use select::predicate::{Attr, Class, Name, Predicate};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use versions::Versioning;
@@ -44,6 +44,8 @@ impl ReleaseType for StableLatest {
                 .unwrap()
                 .strip_prefix(&url)
                 .unwrap()
+                .strip_prefix("release/")
+                .unwrap()
                 .split_once('/')
                 .unwrap();
 
@@ -69,14 +71,15 @@ impl ReleaseType for StableLatest {
 
             let date = {
                 let mut date = node
-                    .find(Class("dl-header-info-platform"))
+                    .find(Class("dl-build-details-popup"))
                     .next()
                     .unwrap()
                     .find(Name("small"))
-                    .next()
+                    .nth(0)
                     .unwrap()
                     .text();
                 let mut date = date.split_off(date.find("on").unwrap() + 3);
+                date.truncate(date.find(" ·").unwrap());
                 date.push_str("-00:00:00");
                 NaiveDateTime::parse_from_str(&date, "%B %d, %Y-%T").unwrap()
             };


### PR DESCRIPTION
Hi,
this patch fixes the parsing of the pages that were changed a bit since the last release.
This is my first lines of Rust so I could have done some wrong things. In case let
me know and I will fix what is not good.

I've tested my changes and with these I'm able to download data about all builds again
(previously I was getting errors on most of the sources.

Cheers!